### PR TITLE
Add custom snooze time option

### DIFF
--- a/app/src/main/java/com/best/deskclock/alarms/AlarmActivity.java
+++ b/app/src/main/java/com/best/deskclock/alarms/AlarmActivity.java
@@ -46,7 +46,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextClock;
 import android.widget.TextView;
 
@@ -126,6 +130,10 @@ public class AlarmActivity extends AppCompatActivity implements View.OnClickList
     private ValueAnimator mAlarmAnimator;
     private ValueAnimator mSnoozeAnimator;
     private ValueAnimator mDismissAnimator;
+
+    private RadioGroup mSnoozeOptions;
+    private EditText mCustomSnoozeTime;
+    private Button mConfirmCustomSnoozeTime;
 
     private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
@@ -250,6 +258,10 @@ public class AlarmActivity extends AppCompatActivity implements View.OnClickList
         mDismissButton = mContentView.findViewById(R.id.dismiss);
         mHintView = mContentView.findViewById(R.id.hint);
         mRingtoneTitle = mContentView.findViewById(R.id.ringtone_title);
+
+        mSnoozeOptions = findViewById(R.id.snooze_options);
+        mCustomSnoozeTime = findViewById(R.id.custom_snooze_time);
+        mConfirmCustomSnoozeTime = findViewById(R.id.confirm_custom_snooze_time);
 
         boolean isRingtoneTitleDisplayed = DataModel.getDataModel().isRingtoneTitleDisplayed();
         if (isRingtoneTitleDisplayed) {
@@ -425,6 +437,8 @@ public class AlarmActivity extends AppCompatActivity implements View.OnClickList
                 dismiss();
             } else if (view == mAlarmButton) {
                 hintAlarmAction();
+            } else if (view == mConfirmCustomSnoozeTime) {
+                onCustomSnoozeTimeEntered();
             }
             return;
         }
@@ -435,6 +449,8 @@ public class AlarmActivity extends AppCompatActivity implements View.OnClickList
             hintDismiss();
         } else if (view == mAlarmButton) {
             hintAlarmAction();
+        } else if (view == mConfirmCustomSnoozeTime) {
+            onCustomSnoozeTimeEntered();
         }
     }
 
@@ -709,6 +725,15 @@ public class AlarmActivity extends AppCompatActivity implements View.OnClickList
 
         // Unbind here, otherwise alarm will keep ringing until activity finishes.
         unbindAlarmService();
+    }
+
+    private void onCustomSnoozeTimeEntered() {
+        String customSnoozeTimeText = mCustomSnoozeTime.getText().toString();
+        if (!customSnoozeTimeText.isEmpty()) {
+            int customSnoozeTime = Integer.parseInt(customSnoozeTimeText);
+            mSnoozeMinutes = customSnoozeTime;
+            snooze();
+        }
     }
 
     /**

--- a/app/src/main/res/layout/alarm_activity.xml
+++ b/app/src/main/res/layout/alarm_activity.xml
@@ -157,6 +157,82 @@
             tools:text="@string/description_direction_both"
             tools:textColor="@color/md_theme_outline" />
 
+        <RadioGroup
+            android:id="@+id/snooze_options"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/title"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <RadioButton
+                android:id="@+id/snooze_5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="5 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_10"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="10 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_15"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="15 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_20"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="20 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_25"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="25 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_30"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="30 mins" />
+
+            <RadioButton
+                android:id="@+id/snooze_custom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Custom" />
+
+        </RadioGroup>
+
+        <EditText
+            android:id="@+id/custom_snooze_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="Enter custom snooze time"
+            android:inputType="number"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/snooze_options"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <Button
+            android:id="@+id/confirm_custom_snooze_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Confirm"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/custom_snooze_time"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout


### PR DESCRIPTION
Add custom snooze time options to the alarm screen.

* Add `RadioGroup` view to `alarm_activity.xml` for selecting snooze time from predefined options (5, 10, 15, 20, 25, 30 mins and custom).
* Add `EditText` view to `alarm_activity.xml` for entering custom snooze time.
* Add `Button` view to `alarm_activity.xml` for confirming custom snooze time.
* Set the visibility of the new views to `gone` initially.
* Add `RadioGroup`, `EditText`, and `Button` views to `AlarmActivity.java`.
* Add method `onCustomSnoozeTimeEntered` in `AlarmActivity.java` to handle custom snooze time entered by the user.
* Update `snooze` method in `AlarmActivity.java` to use the selected snooze time or custom snooze time if entered.

