### PR TITLE
Add setting for hiding the AM/PM part on a digital widget in 12-hour format

### DIFF
--- a/app/src/main/java/com/best/alarmclock/WidgetUtils.java
+++ b/app/src/main/java/com/best/alarmclock/WidgetUtils.java
@@ -165,7 +165,7 @@ public class WidgetUtils {
                 ? ClockUtils.get24ModeFormat(
                 clock.getContext(), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs))
                 : ClockUtils.get12ModeFormat(
-                clock.getContext(), 0.4f, WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs));
+                clock.getContext(), WidgetDAO.getAmPmRatio(prefs), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs));
         final Calendar longestPMTime = Calendar.getInstance();
         longestPMTime.set(0, 0, 0, 23, 59);
         return DateFormat.format(format, longestPMTime);

--- a/app/src/main/java/com/best/alarmclock/WidgetUtils.java
+++ b/app/src/main/java/com/best/alarmclock/WidgetUtils.java
@@ -159,13 +159,13 @@ public class WidgetUtils {
     /**
      * @return "11:59" or "23:59" in the current locale
      */
-    public static CharSequence getLongestTimeString(TextClock clock) {
+    public static CharSequence getLongestTimeString(TextClock clock, boolean materialYou) {
         final SharedPreferences prefs = getDefaultSharedPreferences(clock.getContext());
+        var includeSeconds = materialYou? WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)
+                : WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs);
         final CharSequence format = clock.is24HourModeEnabled()
-                ? ClockUtils.get24ModeFormat(
-                clock.getContext(), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs))
-                : ClockUtils.get12ModeFormat(
-                clock.getContext(), getAmPmRatio(prefs), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs));
+                ? ClockUtils.get24ModeFormat(clock.getContext(), includeSeconds)
+                : ClockUtils.get12ModeFormat(clock.getContext(), getAmPmRatio(materialYou, prefs), includeSeconds);
         final Calendar longestPMTime = Calendar.getInstance();
         longestPMTime.set(0, 0, 0, 23, 59);
         return DateFormat.format(format, longestPMTime);
@@ -174,8 +174,10 @@ public class WidgetUtils {
     /**
      * @return the ratio to use for the AM/PM part on the digital widgets.
      */
-    public static float getAmPmRatio(SharedPreferences prefs) {
-        return WidgetDAO.isAmPmHiddenOnDigitalWidget(prefs)? 0 : 0.4f;
+    public static float getAmPmRatio(boolean materialYou, SharedPreferences prefs) {
+        var amPmHidden = materialYou? WidgetDAO.isAmPmHiddenOnMaterialYouDigitalWidget(prefs)
+                : WidgetDAO.isAmPmHiddenOnDigitalWidget(prefs);
+        return amPmHidden? 0 : 0.4f;
     }
 
     /**

--- a/app/src/main/java/com/best/alarmclock/WidgetUtils.java
+++ b/app/src/main/java/com/best/alarmclock/WidgetUtils.java
@@ -165,10 +165,17 @@ public class WidgetUtils {
                 ? ClockUtils.get24ModeFormat(
                 clock.getContext(), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs))
                 : ClockUtils.get12ModeFormat(
-                clock.getContext(), WidgetDAO.getAmPmRatio(prefs), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs));
+                clock.getContext(), getAmPmRatio(prefs), WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs));
         final Calendar longestPMTime = Calendar.getInstance();
         longestPMTime.set(0, 0, 0, 23, 59);
         return DateFormat.format(format, longestPMTime);
+    }
+
+    /**
+     * @return the ratio to use for the AM/PM part on the digital widgets.
+     */
+    public static float getAmPmRatio(SharedPreferences prefs) {
+        return WidgetDAO.isAmPmHiddenOnDigitalWidget(prefs)? 0 : 0.4f;
     }
 
     /**

--- a/app/src/main/java/com/best/alarmclock/WidgetUtils.java
+++ b/app/src/main/java/com/best/alarmclock/WidgetUtils.java
@@ -159,13 +159,14 @@ public class WidgetUtils {
     /**
      * @return "11:59" or "23:59" in the current locale
      */
-    public static CharSequence getLongestTimeString(TextClock clock, boolean materialYou) {
+    public static CharSequence getLongestTimeString(TextClock clock, boolean isMaterialYou) {
         final SharedPreferences prefs = getDefaultSharedPreferences(clock.getContext());
-        var includeSeconds = materialYou? WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)
+        boolean includeSeconds = isMaterialYou
+                ? WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)
                 : WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs);
         final CharSequence format = clock.is24HourModeEnabled()
                 ? ClockUtils.get24ModeFormat(clock.getContext(), includeSeconds)
-                : ClockUtils.get12ModeFormat(clock.getContext(), getAmPmRatio(materialYou, prefs), includeSeconds);
+                : ClockUtils.get12ModeFormat(clock.getContext(), getAmPmRatio(isMaterialYou, prefs), includeSeconds);
         final Calendar longestPMTime = Calendar.getInstance();
         longestPMTime.set(0, 0, 0, 23, 59);
         return DateFormat.format(format, longestPMTime);
@@ -174,10 +175,11 @@ public class WidgetUtils {
     /**
      * @return the ratio to use for the AM/PM part on the digital widgets.
      */
-    public static float getAmPmRatio(boolean materialYou, SharedPreferences prefs) {
-        var amPmHidden = materialYou? WidgetDAO.isAmPmHiddenOnMaterialYouDigitalWidget(prefs)
+    public static float getAmPmRatio(boolean isMaterialYou, SharedPreferences prefs) {
+        boolean areAmPmHidden = isMaterialYou
+                ? WidgetDAO.isAmPmHiddenOnMaterialYouDigitalWidget(prefs)
                 : WidgetDAO.isAmPmHiddenOnDigitalWidget(prefs);
-        return amPmHidden? 0 : 0.4f;
+        return areAmPmHidden ? 0 : 0.4f;
     }
 
     /**

--- a/app/src/main/java/com/best/alarmclock/materialyouwidgets/MaterialYouDigitalAppWidgetProvider.java
+++ b/app/src/main/java/com/best/alarmclock/materialyouwidgets/MaterialYouDigitalAppWidgetProvider.java
@@ -220,7 +220,8 @@ public class MaterialYouDigitalAppWidgetProvider extends AppWidgetProvider {
             rv.setViewVisibility(R.id.clock, VISIBLE);
             rv.setViewVisibility(R.id.clockForCustomColor, GONE);
             rv.setCharSequence(R.id.clock, "setFormat12Hour", ClockUtils.get12ModeFormat(
-                    context, 0.4f, WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)));
+                    context, WidgetUtils.getAmPmRatio(true, prefs),
+                    WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)));
             rv.setCharSequence(R.id.clock, "setFormat24Hour", ClockUtils.get24ModeFormat(
                     context, WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(prefs)));
         } else {
@@ -399,14 +400,14 @@ public class MaterialYouDigitalAppWidgetProvider extends AppWidgetProvider {
         // Adjust the font sizes.
         measuredSizes.setClockFontSizePx(clockFontSize);
 
-        clock.setText(WidgetUtils.getLongestTimeString(clock));
+        clock.setText(WidgetUtils.getLongestTimeString(clock, true));
         clock.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mClockFontSizePx);
         date.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);
         nextAlarm.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);
         nextAlarmIcon.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mIconFontSizePx);
         nextAlarmIcon.setPadding(measuredSizes.mIconPaddingPx, 0, measuredSizes.mIconPaddingPx, 0);
 
-        clockForCustomColor.setText(WidgetUtils.getLongestTimeString(clockForCustomColor));
+        clockForCustomColor.setText(WidgetUtils.getLongestTimeString(clockForCustomColor, true));
         clockForCustomColor.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mClockFontSizePx);
         dateForCustomColor.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);
         nextAlarmForCustomColor.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);

--- a/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
+++ b/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
@@ -146,8 +146,8 @@ public class DigitalAppWidgetProvider extends AppWidgetProvider {
         );
 
         rv.setCharSequence(R.id.clock, "setFormat12Hour",
-                ClockUtils.get12ModeFormat(context, 0.4f,
-                        WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));
+                ClockUtils.get12ModeFormat(context, WidgetDAO.getAmPmRatio(prefs),
+                                           WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));
         rv.setCharSequence(R.id.clock, "setFormat24Hour",
                 ClockUtils.get24ModeFormat(context,
                         WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));

--- a/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
+++ b/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
@@ -146,7 +146,7 @@ public class DigitalAppWidgetProvider extends AppWidgetProvider {
         );
 
         rv.setCharSequence(R.id.clock, "setFormat12Hour",
-                ClockUtils.get12ModeFormat(context, WidgetUtils.getAmPmRatio(prefs),
+                ClockUtils.get12ModeFormat(context, WidgetUtils.getAmPmRatio(false, prefs),
                         WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));
         rv.setCharSequence(R.id.clock, "setFormat24Hour",
                 ClockUtils.get24ModeFormat(context,
@@ -353,7 +353,7 @@ public class DigitalAppWidgetProvider extends AppWidgetProvider {
 
         // Adjust the font sizes.
         measuredSizes.setClockFontSizePx(clockFontSize);
-        clock.setText(WidgetUtils.getLongestTimeString(clock));
+        clock.setText(WidgetUtils.getLongestTimeString(clock, false));
         clock.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mClockFontSizePx);
         date.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);
         nextAlarm.setTextSize(COMPLEX_UNIT_PX, measuredSizes.mFontSizePx);

--- a/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
+++ b/app/src/main/java/com/best/alarmclock/standardwidgets/DigitalAppWidgetProvider.java
@@ -146,8 +146,8 @@ public class DigitalAppWidgetProvider extends AppWidgetProvider {
         );
 
         rv.setCharSequence(R.id.clock, "setFormat12Hour",
-                ClockUtils.get12ModeFormat(context, WidgetDAO.getAmPmRatio(prefs),
-                                           WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));
+                ClockUtils.get12ModeFormat(context, WidgetUtils.getAmPmRatio(prefs),
+                        WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));
         rv.setCharSequence(R.id.clock, "setFormat24Hour",
                 ClockUtils.get24ModeFormat(context,
                         WidgetDAO.areSecondsDisplayedOnDigitalWidget(prefs)));

--- a/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
+++ b/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
@@ -355,6 +355,14 @@ public final class WidgetDAO {
     }
 
     /**
+     * @return {@code true} if the AM/PM part is hidden on the Material You digital widget; {@code false} otherwise.
+     */
+    public static boolean isAmPmHiddenOnMaterialYouDigitalWidget(SharedPreferences prefs) {
+        return prefs.getBoolean(KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM,
+                DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM);
+    }
+
+    /**
      * @return {@code true} if the cities are displayed on the Material You digital widget;
      * {@code false} otherwise.
      */

--- a/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
+++ b/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
@@ -355,7 +355,8 @@ public final class WidgetDAO {
     }
 
     /**
-     * @return {@code true} if the AM/PM part is hidden on the Material You digital widget; {@code false} otherwise.
+     * @return {@code true} if the AM/PM part is hidden on the Material You digital widget;
+     * {@code false} otherwise.
      */
     public static boolean isAmPmHiddenOnMaterialYouDigitalWidget(SharedPreferences prefs) {
         return prefs.getBoolean(KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM,

--- a/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
+++ b/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
@@ -50,6 +50,20 @@ public final class WidgetDAO {
     }
 
     /**
+     * @return {@code true} if the AM/PM part is hidden on the digital widget; {@code false} otherwise.
+     */
+    public static boolean isAmPmHiddenOnDigitalWidget(SharedPreferences prefs) {
+        return prefs.getBoolean(KEY_DIGITAL_WIDGET_HIDE_AM_PM, DEFAULT_DIGITAL_WIDGET_HIDE_AM_PM);
+    }
+
+    /**
+     * @return the ratio to use for the AM/PM part on the digital widget
+     */
+    public static float getAmPmRatio(SharedPreferences prefs) {
+        return isAmPmHiddenOnDigitalWidget(prefs)? 0 : 0.4f;
+    }
+
+    /**
      * @return {@code true} if the background is displayed on the digital widget; {@code false} otherwise.
      */
     public static boolean isBackgroundDisplayedOnDigitalWidget(SharedPreferences prefs) {

--- a/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
+++ b/app/src/main/java/com/best/deskclock/data/WidgetDAO.java
@@ -57,13 +57,6 @@ public final class WidgetDAO {
     }
 
     /**
-     * @return the ratio to use for the AM/PM part on the digital widget
-     */
-    public static float getAmPmRatio(SharedPreferences prefs) {
-        return isAmPmHiddenOnDigitalWidget(prefs)? 0 : 0.4f;
-    }
-
-    /**
      * @return {@code true} if the background is displayed on the digital widget; {@code false} otherwise.
      */
     public static boolean isBackgroundDisplayedOnDigitalWidget(SharedPreferences prefs) {

--- a/app/src/main/java/com/best/deskclock/settings/DigitalWidgetSettingsFragment.java
+++ b/app/src/main/java/com/best/deskclock/settings/DigitalWidgetSettingsFragment.java
@@ -17,6 +17,7 @@ import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DEF
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DEFAULT_CLOCK_COLOR;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DEFAULT_DATE_COLOR;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DEFAULT_NEXT_ALARM_COLOR;
+import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_HIDE_AM_PM;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DISPLAY_BACKGROUND;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DISPLAY_DATE;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM;
@@ -29,6 +30,7 @@ import android.appwidget.AppWidgetManager;
 import android.content.Intent;
 import android.os.Bundle;
 
+import android.text.format.DateFormat;
 import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.SwitchPreferenceCompat;
@@ -57,6 +59,7 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
     ColorPreference mCustomCityNameColorPref;
     CustomSeekbarPreference mDigitalWidgetMaxClockFontSizePref;
     SwitchPreferenceCompat mDisplaySecondsPref;
+    SwitchPreferenceCompat mHideAmPmPref;
     SwitchPreferenceCompat mDisplayDatePref;
     SwitchPreferenceCompat mDisplayNextAlarmPref;
     SwitchPreferenceCompat mShowBackgroundOnDigitalWidgetPref;
@@ -79,6 +82,7 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
         addPreferencesFromResource(R.xml.settings_customize_digital_widget);
 
         mDisplaySecondsPref = findPreference(KEY_DIGITAL_WIDGET_DISPLAY_SECONDS);
+        mHideAmPmPref = findPreference(KEY_DIGITAL_WIDGET_HIDE_AM_PM);
         mDisplayDatePref = findPreference(KEY_DIGITAL_WIDGET_DISPLAY_DATE);
         mDisplayNextAlarmPref = findPreference(KEY_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM);
         mShowBackgroundOnDigitalWidgetPref = findPreference(KEY_DIGITAL_WIDGET_DISPLAY_BACKGROUND);
@@ -128,7 +132,8 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
     @Override
     public boolean onPreferenceChange(Preference pref, Object newValue) {
         switch (pref.getKey()) {
-            case KEY_DIGITAL_WIDGET_DISPLAY_SECONDS -> Utils.setVibrationTime(requireContext(), 50);
+        case KEY_DIGITAL_WIDGET_DISPLAY_SECONDS, KEY_DIGITAL_WIDGET_HIDE_AM_PM ->
+                        Utils.setVibrationTime(requireContext(), 50);
 
             case KEY_DIGITAL_WIDGET_DISPLAY_BACKGROUND -> {
                 mBackgroundColorPref.setVisible((boolean) newValue);
@@ -205,6 +210,9 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
     private void setupPreferences() {
         mDisplaySecondsPref.setOnPreferenceChangeListener(this);
 
+        mHideAmPmPref.setVisible(! DateFormat.is24HourFormat(requireContext()));
+        mHideAmPmPref.setOnPreferenceChangeListener(this);
+
         mShowBackgroundOnDigitalWidgetPref.setOnPreferenceChangeListener(this);
 
         mBackgroundColorPref.setVisible(WidgetDAO.isBackgroundDisplayedOnDigitalWidget(mPrefs));
@@ -275,6 +283,7 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
 
     private void saveCheckedPreferenceStates() {
         mDisplaySecondsPref.setChecked(WidgetDAO.areSecondsDisplayedOnDigitalWidget(mPrefs));
+        mHideAmPmPref.setChecked(WidgetDAO.isAmPmHiddenOnDigitalWidget(mPrefs));
         mShowBackgroundOnDigitalWidgetPref.setChecked(WidgetDAO.isBackgroundDisplayedOnDigitalWidget(mPrefs));
         mShowCitiesOnDigitalWidgetPref.setChecked(WidgetDAO.areWorldCitiesDisplayedOnDigitalWidget(mPrefs));
         mDefaultClockColorPref.setChecked(WidgetDAO.isDigitalWidgetDefaultClockColor(mPrefs));

--- a/app/src/main/java/com/best/deskclock/settings/DigitalWidgetSettingsFragment.java
+++ b/app/src/main/java/com/best/deskclock/settings/DigitalWidgetSettingsFragment.java
@@ -133,7 +133,7 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
     public boolean onPreferenceChange(Preference pref, Object newValue) {
         switch (pref.getKey()) {
         case KEY_DIGITAL_WIDGET_DISPLAY_SECONDS, KEY_DIGITAL_WIDGET_HIDE_AM_PM ->
-                        Utils.setVibrationTime(requireContext(), 50);
+                Utils.setVibrationTime(requireContext(), 50);
 
             case KEY_DIGITAL_WIDGET_DISPLAY_BACKGROUND -> {
                 mBackgroundColorPref.setVisible((boolean) newValue);
@@ -210,7 +210,7 @@ public class DigitalWidgetSettingsFragment extends ScreenFragment implements Pre
     private void setupPreferences() {
         mDisplaySecondsPref.setOnPreferenceChangeListener(this);
 
-        mHideAmPmPref.setVisible(! DateFormat.is24HourFormat(requireContext()));
+        mHideAmPmPref.setVisible(!DateFormat.is24HourFormat(requireContext()));
         mHideAmPmPref.setOnPreferenceChangeListener(this);
 
         mShowBackgroundOnDigitalWidgetPref.setOnPreferenceChangeListener(this);

--- a/app/src/main/java/com/best/deskclock/settings/MaterialYouDigitalWidgetSettingsFragment.java
+++ b/app/src/main/java/com/best/deskclock/settings/MaterialYouDigitalWidgetSettingsFragment.java
@@ -18,6 +18,7 @@ import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGIT
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_DEFAULT_NEXT_ALARM_COLOR;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_DATE;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM;
+import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_MAXIMUM_CLOCK_FONT_SIZE;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_SECONDS_DISPLAYED;
 import static com.best.deskclock.settings.PreferencesKeys.KEY_MATERIAL_YOU_DIGITAL_WIDGET_WORLD_CITIES_DISPLAYED;
@@ -27,6 +28,7 @@ import android.appwidget.AppWidgetManager;
 import android.content.Intent;
 import android.os.Bundle;
 
+import android.text.format.DateFormat;
 import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.SwitchPreferenceCompat;
@@ -55,6 +57,7 @@ public class MaterialYouDigitalWidgetSettingsFragment extends ScreenFragment
     ColorPreference mCustomCityNameColorPref;
     CustomSeekbarPreference mDigitalWidgetMaxClockFontSizePref;
     SwitchPreferenceCompat mDisplaySecondsPref;
+    SwitchPreferenceCompat mHideAmPmPref;
     SwitchPreferenceCompat mDisplayDatePref;
     SwitchPreferenceCompat mDisplayNextAlarmPref;
     SwitchPreferenceCompat mShowCitiesOnDigitalWidgetPref;
@@ -76,6 +79,7 @@ public class MaterialYouDigitalWidgetSettingsFragment extends ScreenFragment
         addPreferencesFromResource(R.xml.settings_customize_material_you_digital_widget);
 
         mDisplaySecondsPref = findPreference(KEY_MATERIAL_YOU_DIGITAL_WIDGET_SECONDS_DISPLAYED);
+        mHideAmPmPref = findPreference(KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM);
         mDisplayDatePref = findPreference(KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_DATE);
         mDisplayNextAlarmPref = findPreference(KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM);
         mShowCitiesOnDigitalWidgetPref = findPreference(KEY_MATERIAL_YOU_DIGITAL_WIDGET_WORLD_CITIES_DISPLAYED);
@@ -123,7 +127,8 @@ public class MaterialYouDigitalWidgetSettingsFragment extends ScreenFragment
     @Override
     public boolean onPreferenceChange(Preference pref, Object newValue) {
         switch (pref.getKey()) {
-            case KEY_MATERIAL_YOU_DIGITAL_WIDGET_SECONDS_DISPLAYED -> Utils.setVibrationTime(requireContext(), 50);
+        case KEY_MATERIAL_YOU_DIGITAL_WIDGET_SECONDS_DISPLAYED, KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM ->
+                Utils.setVibrationTime(requireContext(), 50);
 
             case KEY_MATERIAL_YOU_DIGITAL_WIDGET_WORLD_CITIES_DISPLAYED -> {
                 mDefaultCityClockColorPref.setVisible((boolean) newValue);
@@ -195,6 +200,9 @@ public class MaterialYouDigitalWidgetSettingsFragment extends ScreenFragment
     private void setupPreferences() {
         mDisplaySecondsPref.setOnPreferenceChangeListener(this);
 
+        mHideAmPmPref.setVisible(!DateFormat.is24HourFormat(requireContext()));
+        mHideAmPmPref.setOnPreferenceChangeListener(this);
+
         List<City> selectedCities = DataModel.getDataModel().getSelectedCities();
         final boolean showHomeClock = SettingsDAO.getShowHomeClock(requireContext(), mPrefs);
         mShowCitiesOnDigitalWidgetPref.setVisible(!selectedCities.isEmpty() || showHomeClock);
@@ -260,6 +268,7 @@ public class MaterialYouDigitalWidgetSettingsFragment extends ScreenFragment
 
     private void saveCheckedPreferenceStates() {
         mDisplaySecondsPref.setChecked(WidgetDAO.areSecondsDisplayedOnMaterialYouDigitalWidget(mPrefs));
+        mHideAmPmPref.setChecked(WidgetDAO.isAmPmHiddenOnMaterialYouDigitalWidget(mPrefs));
         mShowCitiesOnDigitalWidgetPref.setChecked(WidgetDAO.areWorldCitiesDisplayedOnMaterialYouDigitalWidget(mPrefs));
         mDefaultClockColorPref.setChecked(WidgetDAO.isMaterialYouDigitalWidgetDefaultClockColor(mPrefs));
         mDisplayDatePref.setChecked(WidgetDAO.isDateDisplayedOnMaterialYouDigitalWidget(mPrefs));

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
@@ -145,6 +145,7 @@ public class PreferencesDefaultValues {
 
     // DigitalWidgetSettingsFragment
     public static final boolean DEFAULT_DIGITAL_WIDGET_DISPLAY_SECONDS = false;
+    public static final boolean DEFAULT_DIGITAL_WIDGET_HIDE_AM_PM = false;
     public static final boolean DEFAULT_DIGITAL_WIDGET_DISPLAY_DATE = true;
     public static final boolean DEFAULT_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM = true;
     public static final boolean DEFAULT_DIGITAL_WIDGET_DISPLAY_BACKGROUND = false;

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
@@ -164,6 +164,7 @@ public class PreferencesDefaultValues {
 
     // Material You Digital Widget
     public static final boolean DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_SECONDS = false;
+    public static final boolean DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM = false;
     public static final boolean DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_DATE = true;
     public static final boolean DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM = true;
     public static final boolean DEFAULT_MATERIAL_YOU_DIGITAL_WIDGET_WORLD_CITIES_DISPLAYED = true;

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
@@ -159,6 +159,7 @@ public class PreferencesKeys {
 
     // Digital Widget
     public static final String KEY_DIGITAL_WIDGET_DISPLAY_SECONDS = "key_digital_widget_display_seconds";
+    public static final String KEY_DIGITAL_WIDGET_HIDE_AM_PM = "key_digital_widget_hide_am_pm";
     public static final String KEY_DIGITAL_WIDGET_DISPLAY_DATE = "key_digital_widget_display_date";
     public static final String KEY_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM = "key_digital_widget_display_next_alarm";
     public static final String KEY_DIGITAL_WIDGET_DISPLAY_BACKGROUND = "key_digital_widget_display_background";

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
@@ -209,6 +209,8 @@ public class PreferencesKeys {
     // Material You Digital Widget
     public static final String KEY_MATERIAL_YOU_DIGITAL_WIDGET_SECONDS_DISPLAYED =
             "key_material_you_digital_widget_seconds_displayed";
+    public static final String KEY_MATERIAL_YOU_DIGITAL_WIDGET_HIDE_AM_PM =
+            "key_material_you_digital_widget_hide_am_pm";
     public static final String KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_DATE =
             "key_material_you_digital_widget_display_date";
     public static final String KEY_MATERIAL_YOU_DIGITAL_WIDGET_DISPLAY_NEXT_ALARM =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,8 @@
     <string name="clock_style">Style</string>
     <!-- Header for a setting referring to showing seconds on the main clock -->
     <string name="display_clock_seconds_pref">Display time with seconds</string>
+    <!-- Header for a setting referring to hiding the AM/PM part on the main clock -->
+    <string name="hide_clock_am_pm_pref">Hide AM/PM text</string>
     <!-- Title for preference to change date & time -->
     <string name="open_date_settings">Change date \u0026 time</string>
     <!-- Setting title for changing the clock style to Analog. -->

--- a/app/src/main/res/xml/settings_customize_digital_widget.xml
+++ b/app/src/main/res/xml/settings_customize_digital_widget.xml
@@ -23,6 +23,14 @@
             tools:layout="@layout/settings_preference_layout" />
 
         <SwitchPreferenceCompat
+            android:key="key_digital_widget_hide_am_pm"
+            android:title="@string/hide_clock_am_pm_pref"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            tools:layout="@layout/settings_preference_layout" />
+
+        <SwitchPreferenceCompat
             android:key="key_digital_widget_display_background"
             android:title="@string/widget_background_title"
             android:defaultValue="false"

--- a/app/src/main/res/xml/settings_customize_material_you_digital_widget.xml
+++ b/app/src/main/res/xml/settings_customize_material_you_digital_widget.xml
@@ -23,6 +23,14 @@
             tools:layout="@layout/settings_preference_layout" />
 
         <SwitchPreferenceCompat
+            android:key="key_material_you_digital_widget_hide_am_pm"
+            android:title="@string/hide_clock_am_pm_pref"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            tools:layout="@layout/settings_preference_layout" />
+
+        <SwitchPreferenceCompat
             android:key="key_material_you_digital_widget_world_cities_displayed"
             android:title="@string/digital_widget_city_title"
             android:defaultValue="true"


### PR DESCRIPTION
Should I apply this to any other widget too?
Is `WidgetDAO` the right place for `getAmPmRatio`?

Fixes part of #310.
