### PR TITLE
Use correct color palette in night mode text clock

### DIFF
--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -49,7 +49,7 @@
 
     <!-- WIDGET COLORS -->
     <color name="widget_background_color">@android:color/system_accent2_800</color>
-    <color name="digital_widget_time_color">@android:color/system_accent2_100</color>
+    <color name="digital_widget_time_color">@android:color/system_accent1_100</color>
     <color name="vertical_digital_widget_hour_color">@android:color/system_accent2_100</color>
     <color name="vertical_digital_widget_minute_color">@android:color/system_accent1_100</color>
     <color name="next_alarm_widget_title_color">@android:color/system_accent2_100</color>


### PR DESCRIPTION
This turns current

<img width="200" alt="image" src="https://github.com/user-attachments/assets/2d255d12-0d59-4118-9de0-9599ca34faa4" />

to 

<img width="200" alt="image" src="https://github.com/user-attachments/assets/886eea9d-9dc7-45cb-8d5e-64a03c3e355b" />

(please compare with Google's clock and specifically in the dark mode)
