### PR TITLE
Add new Option DISPLAY_ALARM_ALERTS in the Alarm->Display Settings.

### DIFF
--- a/app/src/main/java/com/best/deskclock/alarms/AlarmActivity.java
+++ b/app/src/main/java/com/best/deskclock/alarms/AlarmActivity.java
@@ -976,32 +976,36 @@ public class AlarmActivity extends BaseActivity implements View.OnClickListener,
      * Show alert after alarm has been snoozed or dismissed.
      */
     private void showAlert(final int titleResId, final String infoText, final String accessibilityText) {
-        mAlertView.setVisibility(View.VISIBLE);
+        if (SettingsDAO.isAlertsDisplayed(mPrefs)) {
+            mAlertView.setVisibility(View.VISIBLE);
 
-        mAlertTitleView.setText(titleResId);
-        mAlertTitleView.setTypeface(mGeneralBoldTypeface);
-        mAlertTitleView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
-        mAlertTitleView.setTextColor(mAlarmTitleColor);
+            mAlertTitleView.setText(titleResId);
+            mAlertTitleView.setTypeface(mGeneralBoldTypeface);
+            mAlertTitleView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
+            mAlertTitleView.setTextColor(mAlarmTitleColor);
 
-        if (infoText != null) {
-            mAlertInfoView.setVisibility(View.VISIBLE);
-            mAlertInfoView.setTypeface(mGeneralBoldTypeface);
-            mAlertInfoView.setText(infoText);
-            mAlertInfoView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
-            mAlertInfoView.setTextColor(mAlarmTitleColor);
+            if (infoText != null) {
+                mAlertInfoView.setVisibility(View.VISIBLE);
+                mAlertInfoView.setTypeface(mGeneralBoldTypeface);
+                mAlertInfoView.setText(infoText);
+                mAlertInfoView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
+                mAlertInfoView.setTextColor(mAlarmTitleColor);
+            }
+
+
+            mAlertView.setAlpha(0f);
+            mAlertView.animate()
+                    .alpha(1f)
+                    .setDuration(ALERT_REVEAL_DURATION_MILLIS)
+                    .withEndAction(() -> {
+                        mAlertView.announceForAccessibility(accessibilityText);
+                        mHandler.postDelayed(this::finish, ALERT_DISMISS_DELAY_MILLIS);
+                    })
+                    .start();
+        } else {
+            this.finish();
         }
-
         mContentView.setVisibility(View.GONE);
-
-        mAlertView.setAlpha(0f);
-        mAlertView.animate()
-                .alpha(1f)
-                .setDuration(ALERT_REVEAL_DURATION_MILLIS)
-                .withEndAction(() -> {
-                    mAlertView.announceForAccessibility(accessibilityText);
-                    mHandler.postDelayed(this::finish, ALERT_DISMISS_DELAY_MILLIS);
-                })
-                .start();
     }
 
 }

--- a/app/src/main/java/com/best/deskclock/data/SettingsDAO.java
+++ b/app/src/main/java/com/best/deskclock/data/SettingsDAO.java
@@ -1355,6 +1355,11 @@ public final class SettingsDAO {
         return prefs.getBoolean(KEY_DISPLAY_RINGTONE_TITLE, DEFAULT_DISPLAY_RINGTONE_TITLE);
     }
 
+    public static boolean isAlertsDisplayed(SharedPreferences prefs) {
+        // Default value must match the one in res/xml/settings_alarm_display.xml
+        return prefs.getBoolean(KEY_DISPLAY_ALARM_ALERTS, DEFAULT_DISPLAY_ALARM_ALERTS);
+    }
+
     /**
      * @return a value indicating the ringtone title color.
      */

--- a/app/src/main/java/com/best/deskclock/settings/AlarmDisplayPreviewActivity.java
+++ b/app/src/main/java/com/best/deskclock/settings/AlarmDisplayPreviewActivity.java
@@ -650,29 +650,32 @@ public class AlarmDisplayPreviewActivity extends BaseActivity
      * Show alert after alarm has been snoozed or dismissed.
      */
     private void showAlert(final int titleResId, final String infoText) {
-        mAlertView.setVisibility(VISIBLE);
+        if (SettingsDAO.isAlertsDisplayed(mPrefs)) {
+            mAlertView.setVisibility(VISIBLE);
 
-        mAlertTitleView.setText(titleResId);
-        mAlertTitleView.setTypeface(mGeneralBoldTypeface);
-        mAlertTitleView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
-        mAlertTitleView.setTextColor(mAlarmTitleColor);
+            mAlertTitleView.setText(titleResId);
+            mAlertTitleView.setTypeface(mGeneralBoldTypeface);
+            mAlertTitleView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
+            mAlertTitleView.setTextColor(mAlarmTitleColor);
 
-        if (infoText != null) {
-            mAlertInfoView.setVisibility(VISIBLE);
-            mAlertInfoView.setText(infoText);
-            mAlertInfoView.setTypeface(mGeneralBoldTypeface);
-            mAlertInfoView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
-            mAlertInfoView.setTextColor(mAlarmTitleColor);
+            if (infoText != null) {
+                mAlertInfoView.setVisibility(VISIBLE);
+                mAlertInfoView.setText(infoText);
+                mAlertInfoView.setTypeface(mGeneralBoldTypeface);
+                mAlertInfoView.setTextSize(TypedValue.COMPLEX_UNIT_SP, mAlarmTitleFontSize);
+                mAlertInfoView.setTextColor(mAlarmTitleColor);
+            }
+
+            mAlertView.setAlpha(0f);
+            mAlertView.animate()
+                    .alpha(1f)
+                    .setDuration(ALERT_REVEAL_DURATION_MILLIS)
+                    .withEndAction(() -> mHandler.postDelayed(this::finishActivity, ALERT_DISMISS_DELAY_MILLIS))
+                    .start();
+        } else {
+            this.finishActivity();
         }
-
         mContentView.setVisibility(GONE);
-
-        mAlertView.setAlpha(0f);
-        mAlertView.animate()
-                .alpha(1f)
-                .setDuration(ALERT_REVEAL_DURATION_MILLIS)
-                .withEndAction(() -> mHandler.postDelayed(this::finishActivity, ALERT_DISMISS_DELAY_MILLIS))
-                .start();
     }
 
     private void finishActivity() {

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesDefaultValues.java
@@ -127,6 +127,7 @@ public class PreferencesDefaultValues {
     public static final int DEFAULT_ALARM_TITLE_FONT_SIZE_PREF = 30;
     public static final int DEFAULT_ALARM_SHADOW_COLOR = Color.parseColor("#80FFFFFF");
     public static final int DEFAULT_RINGTONE_TITLE_COLOR = Color.WHITE;
+    public static final boolean DEFAULT_DISPLAY_ALARM_ALERTS = true;
     public static final boolean DEFAULT_ENABLE_BLUR_EFFECT = false;
     public static final int DEFAULT_BLUR_INTENSITY = 20;
     public static int getDefaultAlarmInversePrimaryColor(Context context) {

--- a/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
+++ b/app/src/main/java/com/best/deskclock/settings/PreferencesKeys.java
@@ -134,6 +134,7 @@ public class PreferencesKeys {
     public static final String KEY_ALARM_SHADOW_COLOR = "key_alarm_shadow_color";
     public static final String KEY_ALARM_SHADOW_OFFSET = "key_alarm_shadow_offset";
     public static final String KEY_DISPLAY_RINGTONE_TITLE = "key_display_ringtone_title";
+    public static final String KEY_DISPLAY_ALARM_ALERTS = "key_display_alarm_alerts";
     public static final String KEY_RINGTONE_TITLE_COLOR = "key_ringtone_title_color";
     public static final String KEY_ALARM_BACKGROUND_IMAGE = "key_alarm_background_image";
     public static final String KEY_ENABLE_ALARM_BLUR_EFFECT = "key_enable_alarm_blur_effect";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -555,6 +555,8 @@
     <string name="display_ringtone_title">Display ringtone title</string>
     <!-- Setting title for customizing the ringtone title color. -->
     <string name="ringtone_title_color">Ringtone title color</string>
+    <!-- Setting title to display the alert after alarm has been snoozed or dismissed. -->
+    <string name="display_alarm_alerts">Show alert after alarm has been snoozed or dismissed.</string>
     <!-- Setting title to set the blur intensity. -->
     <string name="blur_intensity_title">Blur intensity</string>
     <!-- Setting title to choose a background image. -->

--- a/app/src/main/res/xml/settings_alarm_display.xml
+++ b/app/src/main/res/xml/settings_alarm_display.xml
@@ -276,6 +276,14 @@
             app:singleLineTitle="false"
             tools:layout="@layout/settings_preference_seekbar_layout" />
 
+        <com.best.deskclock.settings.custompreference.CustomSwitchPreference
+            android:key="key_display_alarm_alerts"
+            android:title="@string/display_alarm_alerts"
+            android:defaultValue="true"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            tools:layout="@layout/settings_preference_layout" />
+
         <com.best.deskclock.settings.custompreference.CustomPreference
             android:key="key_alarm_preview"
             android:title="@string/preview_title"


### PR DESCRIPTION
The option defaults to true(current behaviour) and determines if the Alarm(DisplayPreview)Activity.showAlert Method actually shows the Alert after snooze/dismiss.

