### PR TITLE
Show stopwatch notification on lock screen

### DIFF
--- a/app/src/main/java/com/best/deskclock/data/StopwatchNotificationBuilder.java
+++ b/app/src/main/java/com/best/deskclock/data/StopwatchNotificationBuilder.java
@@ -131,6 +131,7 @@ class StopwatchNotificationBuilder {
                 .setSmallIcon(R.drawable.ic_tab_stopwatch_static)
                 .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                 .setColor(context.getColor(R.color.md_theme_primary))
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setGroup(nm.getStopwatchNotificationGroupKey());
 
         for (Action action : actions) {


### PR DESCRIPTION
Fixes #555

The notification was getting hidden on the lock screen. Added VISIBILITY_PUBLIC to make it show up properly.