### PR TITLE
feat: add intent extras to timer notifications for 3rd-party integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
         }
     }
 
-    def commitNumber = 32
+    def commitNumber = 33
 
     def buildCommit = providers.exec {
         commandLine('git', 'rev-parse', '--short=7', 'HEAD')

--- a/app/src/main/java/com/best/deskclock/data/TimerNotificationBuilder.java
+++ b/app/src/main/java/com/best/deskclock/data/TimerNotificationBuilder.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.SystemClock;
 import android.text.TextUtils;
 import android.widget.RemoteViews;
@@ -198,6 +199,13 @@ class TimerNotificationBuilder {
             .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
             .setColor(ContextCompat.getColor(context, R.color.md_theme_primary))
             .setGroup(nm.getTimerNotificationGroupKey());
+
+        Bundle extras = new Bundle();
+        extras.putLong("android.chronometerBase", base);
+        extras.putBoolean("android.chronometerCountDown", true);
+        extras.putBoolean(context.getPackageName() + ".timerIsRunning", running);
+        extras.putLong(context.getPackageName() + ".timerRemainingMs", timer.getRemainingTime());
+        notification.addExtras(extras);
 
         for (Action action : actions) {
             notification.addAction(action);


### PR DESCRIPTION
Follow up of https://github.com/BlackyHawky/Clock/pull/621

### What does this PR do?
Adds standard and custom `Bundle` extras to the timer notification builder. 

### Why is this needed?
It was requested by one of my Dynamic Island app users.

Currently, third-party apps (like Tasker, KLWP, or Dynamic Island implementations) have to rely on complex and brittle `RemoteViews` reflection to read the timer state from this app, as standard notification extras aren't provided. 

By explicitly attaching `android.chronometerBase` and `android.chronometerCountDown` (which are standard Android APIs), as well as a couple of custom extras, third-party tools can seamlessly integrate with this clock app without hacky workarounds. 

This doesn't change any internal behavior or UI of the app itself.